### PR TITLE
[RVC][v10.4.3-rx-1.0.6] Added project generation support for RX24T

### DIFF
--- a/configuration/freertos.xml
+++ b/configuration/freertos.xml
@@ -25,6 +25,7 @@
         <group>RX231</group>
         <group>RX23W</group>
         <group>RX23E-A</group>
+        <group>RX24T</group>
         <group>RX64M</group>
         <group>RX651</group>
         <group>RX65N</group>
@@ -60,6 +61,7 @@
         <group>RX231</group>
         <group>RX23W</group>
         <group>RX23E-A</group>
+        <group>RX24T</group>
         <group>RX64M</group>
         <group>RX651</group>
         <group>RX65N</group>
@@ -87,7 +89,7 @@
     <package>
         <type>rtosmodule</type>
         <name>FreeRTOSKernel</name>
-        <version>10.4.3-rx-1.0.5</version>
+        <version>10.4.3-rx-1.0.6</version>
         <!-- include path setting -->
         <incdir>
             <path>src/FreeRTOS/Source/include</path>
@@ -107,6 +109,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX24T</group>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2</path>
         </incdir>
         <incdir>
@@ -147,6 +150,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX24T</group>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2</path>
         </incdir>
         <incdir>
@@ -237,6 +241,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX24T</group>
             <folder>portable/Renesas/RX600v2</folder>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2</path>
         </impdir>
@@ -274,6 +279,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX24T</group>
             <folder>portable/GCC/RX600v2</folder>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2</path>
         </impdir>
@@ -372,6 +378,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX24T</group>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2/portmacro.h</path>
         </property>
         <property id="portBYTE_ALIGNMENT">
@@ -412,6 +419,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX24T</group>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2/portmacro.h</path>
         </property>
         <property id="portBYTE_ALIGNMENT">


### PR DESCRIPTION
# [v10.4.3-rx-1.0.6] Added project generation support for RX24T

Description
-----------
Updated ```./configuration/freertos.xml```:
   - Added support for RX24T

Test Steps
-----------
Result:
1. Tested with CCRX. **OK**.
2. Tested with GCC. **OK**.

Test spec. and report: on CFL.
Review: on CFL.

Related Issue
-----------
None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
