### PR TITLE
Add RX26T project generation support.

### DIFF
--- a/configuration/freertos.xml
+++ b/configuration/freertos.xml
@@ -25,6 +25,7 @@
         <group>RX231</group>
         <group>RX23W</group>
         <group>RX23E-A</group>
+        <group>RX23E-B</group>
         <group>RX24T</group>
         <group>RX26T</group>
         <group>RX64M</group>
@@ -62,6 +63,7 @@
         <group>RX231</group>
         <group>RX23W</group>
         <group>RX23E-A</group>
+        <group>RX23E-B</group>
         <group>RX24T</group>
         <group>RX26T</group>
         <group>RX64M</group>
@@ -111,6 +113,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX23E-B</group>
             <group>RX24T</group>
             <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2</path>
@@ -153,6 +156,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX23E-B</group>
             <group>RX24T</group>
             <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2</path>
@@ -245,6 +249,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX23E-B</group>
             <group>RX24T</group>
             <group>RX26T</group>
             <folder>portable/Renesas/RX600v2</folder>
@@ -284,6 +289,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX23E-B</group>
             <group>RX24T</group>
             <group>RX26T</group>
             <folder>portable/GCC/RX600v2</folder>
@@ -384,6 +390,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX23E-B</group>
             <group>RX24T</group>
             <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2/portmacro.h</path>
@@ -426,6 +433,7 @@
             <group>RX231</group>
             <group>RX23W</group>
             <group>RX23E-A</group>
+            <group>RX23E-B</group>
             <group>RX24T</group>
             <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2/portmacro.h</path>

--- a/configuration/freertos.xml
+++ b/configuration/freertos.xml
@@ -26,6 +26,7 @@
         <group>RX23W</group>
         <group>RX23E-A</group>
         <group>RX24T</group>
+        <group>RX26T</group>
         <group>RX64M</group>
         <group>RX651</group>
         <group>RX65N</group>
@@ -62,6 +63,7 @@
         <group>RX23W</group>
         <group>RX23E-A</group>
         <group>RX24T</group>
+        <group>RX26T</group>
         <group>RX64M</group>
         <group>RX651</group>
         <group>RX65N</group>
@@ -110,6 +112,7 @@
             <group>RX23W</group>
             <group>RX23E-A</group>
             <group>RX24T</group>
+            <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2</path>
         </incdir>
         <incdir>
@@ -151,6 +154,7 @@
             <group>RX23W</group>
             <group>RX23E-A</group>
             <group>RX24T</group>
+            <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2</path>
         </incdir>
         <incdir>
@@ -242,6 +246,7 @@
             <group>RX23W</group>
             <group>RX23E-A</group>
             <group>RX24T</group>
+            <group>RX26T</group>
             <folder>portable/Renesas/RX600v2</folder>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2</path>
         </impdir>
@@ -280,6 +285,7 @@
             <group>RX23W</group>
             <group>RX23E-A</group>
             <group>RX24T</group>
+            <group>RX26T</group>
             <folder>portable/GCC/RX600v2</folder>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2</path>
         </impdir>
@@ -379,6 +385,7 @@
             <group>RX23W</group>
             <group>RX23E-A</group>
             <group>RX24T</group>
+            <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/Renesas/RX600v2/portmacro.h</path>
         </property>
         <property id="portBYTE_ALIGNMENT">
@@ -420,6 +427,7 @@
             <group>RX23W</group>
             <group>RX23E-A</group>
             <group>RX24T</group>
+            <group>RX26T</group>
             <path>src/FreeRTOS/Source/portable/GCC/RX600v2/portmacro.h</path>
         </property>
         <property id="portBYTE_ALIGNMENT">

--- a/portable/GCC/RX100/readme.txt
+++ b/portable/GCC/RX100/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX100/readme.txt
+++ b/portable/GCC/RX100/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/GCC/RX100/readme.txt
+++ b/portable/GCC/RX100/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX200/readme.txt
+++ b/portable/GCC/RX200/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX200/readme.txt
+++ b/portable/GCC/RX200/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/GCC/RX200/readme.txt
+++ b/portable/GCC/RX200/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX600/readme.txt
+++ b/portable/GCC/RX600/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX600/readme.txt
+++ b/portable/GCC/RX600/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/GCC/RX600/readme.txt
+++ b/portable/GCC/RX600/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX600v2/readme.txt
+++ b/portable/GCC/RX600v2/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX600v2/readme.txt
+++ b/portable/GCC/RX600v2/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/GCC/RX600v2/readme.txt
+++ b/portable/GCC/RX600v2/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX700v3_DPFPU/readme.txt
+++ b/portable/GCC/RX700v3_DPFPU/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/GCC/RX700v3_DPFPU/readme.txt
+++ b/portable/GCC/RX700v3_DPFPU/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/GCC/RX700v3_DPFPU/readme.txt
+++ b/portable/GCC/RX700v3_DPFPU/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX100/readme.txt
+++ b/portable/Renesas/RX100/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX100/readme.txt
+++ b/portable/Renesas/RX100/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/Renesas/RX100/readme.txt
+++ b/portable/Renesas/RX100/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX200/readme.txt
+++ b/portable/Renesas/RX200/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX200/readme.txt
+++ b/portable/Renesas/RX200/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/Renesas/RX200/readme.txt
+++ b/portable/Renesas/RX200/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX600/readme.txt
+++ b/portable/Renesas/RX600/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX600/readme.txt
+++ b/portable/Renesas/RX600/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/Renesas/RX600/readme.txt
+++ b/portable/Renesas/RX600/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX600v2/readme.txt
+++ b/portable/Renesas/RX600v2/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX600v2/readme.txt
+++ b/portable/Renesas/RX600v2/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/Renesas/RX600v2/readme.txt
+++ b/portable/Renesas/RX600v2/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX700v3_DPFPU/readme.txt
+++ b/portable/Renesas/RX700v3_DPFPU/readme.txt
@@ -21,6 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600

--- a/portable/Renesas/RX700v3_DPFPU/readme.txt
+++ b/portable/Renesas/RX700v3_DPFPU/readme.txt
@@ -17,6 +17,7 @@ RX21A           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)
 RX220           RXv1    No          ---         Renesas/RX200 (*3)      N/A (*3)            N/A (*3)
 RX230,RX231     RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23E-A         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
+RX23E-B         RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2

--- a/portable/Renesas/RX700v3_DPFPU/readme.txt
+++ b/portable/Renesas/RX700v3_DPFPU/readme.txt
@@ -21,7 +21,7 @@ RX23W           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX60
 RX23T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24T           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
 RX24U           RXv2    Yes         ---         Renesas/RX600v2         GCC/RX600v2         IAR/RXv2
-RX26T           RXv3    Yes         ---         Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2
+RX26T           RXv3    Yes         No          Renesas/RX600v2 (*5)    GCC/RX600v2 (*5)    IAR/RXv2 (*5)
 
 RX610           RXv1    Yes         ---         N/A (*4)                N/A (*4)            N/A (*4)
 RX62N,RX621     RXv1    Yes         ---         Renesas/RX600           GCC/RX600           IAR/RX600


### PR DESCRIPTION
Add RX26T project generation support.

Description
-----------
**Environment**:
- e2studio (2022-07) v202210 (beta) added support for RX26T  (build: 20220905)
- Motor Control Kit- RX26T (R5F526TFCDFP)
- CCRX v3.04.00  &  GCC 8.3.0.202202
- RDP_v1.36 + BSP v7.30 alpha 2
- Baseline: [xuan97z1/FreeRTOS-Kernel at rx_development_v10.4.3 (github.com)](https://github.com/xuan97z1/FreeRTOS-Kernel/tree/rx_development_v10.4.3) (commit# a7ab0b7)

Test Steps
-----------
1. Renesas CCRX PG + Build + Led blink demo: OK
2. Renesas GNURX (GCC) PG + Build + Led blink demo: OK

Test report on CFL.

Related Issue
-----------
Reported on CFL


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
