### PR TITLE
Update portSET_INTERRUPT_MASK_FROM_ISR as a macro to function

### DIFF
--- a/portable/GCC/RX100/portmacro.h
+++ b/portable/GCC/RX100/portmacro.h
@@ -124,8 +124,16 @@ extern void vTaskExitCritical( void );
 /* As this port allows interrupt nesting... */
 uint32_t ulPortGetIPL( void ) __attribute__((naked));
 void vPortSetIPL( uint32_t ulNewIPL ) __attribute__((naked));
-#define portSET_INTERRUPT_MASK_FROM_ISR() ulPortGetIPL(); portDISABLE_INTERRUPTS()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) vPortSetIPL( uxSavedInterruptStatus )
+
+ static int32_t set_interrupt_mask_from_isr( void );
+ static int32_t set_interrupt_mask_from_isr( void )
+ {
+	 int32_t tmp = ulPortGetIPL();
+	 vPortSetIPL( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+	 return tmp;
+ }
+ #define portSET_INTERRUPT_MASK_FROM_ISR()    set_interrupt_mask_from_isr()
+ #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( ( long ) uxSavedInterruptStatus )
 
 /* Tickless idle/low power functionality. */
 #if configUSE_TICKLESS_IDLE == 1

--- a/portable/GCC/RX200/portmacro.h
+++ b/portable/GCC/RX200/portmacro.h
@@ -127,8 +127,16 @@ extern void vTaskExitCritical( void );
 /* As this port allows interrupt nesting... */
 uint32_t ulPortGetIPL( void ) __attribute__((naked));
 void vPortSetIPL( uint32_t ulNewIPL ) __attribute__((naked));
-#define portSET_INTERRUPT_MASK_FROM_ISR() ulPortGetIPL(); portDISABLE_INTERRUPTS()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) vPortSetIPL( uxSavedInterruptStatus )
+
+ static int32_t set_interrupt_mask_from_isr( void );
+ static int32_t set_interrupt_mask_from_isr( void )
+ {
+	 int32_t tmp = ulPortGetIPL();
+	 vPortSetIPL( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+	 return tmp;
+ }
+ #define portSET_INTERRUPT_MASK_FROM_ISR()    set_interrupt_mask_from_isr()
+ #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RX600/portmacro.h
+++ b/portable/GCC/RX600/portmacro.h
@@ -127,8 +127,16 @@ extern void vTaskExitCritical( void );
 /* As this port allows interrupt nesting... */
 uint32_t ulPortGetIPL( void ) __attribute__((naked));
 void vPortSetIPL( uint32_t ulNewIPL ) __attribute__((naked));
-#define portSET_INTERRUPT_MASK_FROM_ISR() ulPortGetIPL(); portDISABLE_INTERRUPTS()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) vPortSetIPL( uxSavedInterruptStatus )
+
+ static int32_t set_interrupt_mask_from_isr( void );
+ static int32_t set_interrupt_mask_from_isr( void )
+ {
+	 int32_t tmp = ulPortGetIPL();
+	 vPortSetIPL( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+	 return tmp;
+ }
+ #define portSET_INTERRUPT_MASK_FROM_ISR()    set_interrupt_mask_from_isr()
+ #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RX600v2/portmacro.h
+++ b/portable/GCC/RX600v2/portmacro.h
@@ -127,8 +127,16 @@ extern void vTaskExitCritical( void );
 /* As this port allows interrupt nesting... */
 uint32_t ulPortGetIPL( void ) __attribute__((naked));
 void vPortSetIPL( uint32_t ulNewIPL ) __attribute__((naked));
-#define portSET_INTERRUPT_MASK_FROM_ISR() ulPortGetIPL(); portDISABLE_INTERRUPTS()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) vPortSetIPL( uxSavedInterruptStatus )
+
+ static int32_t set_interrupt_mask_from_isr( void );
+ static int32_t set_interrupt_mask_from_isr( void )
+ {
+	 int32_t tmp = ulPortGetIPL();
+	 vPortSetIPL( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+	 return tmp;
+ }
+ #define portSET_INTERRUPT_MASK_FROM_ISR()    set_interrupt_mask_from_isr()
+ #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RX700v3_DPFPU/portmacro.h
+++ b/portable/GCC/RX700v3_DPFPU/portmacro.h
@@ -149,10 +149,18 @@
     #define portEXIT_CRITICAL()     vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-    uint32_t ulPortGetIPL( void ) __attribute__( ( naked ) );
-    void vPortSetIPL( uint32_t ulNewIPL ) __attribute__( ( naked ) );
-    #define portSET_INTERRUPT_MASK_FROM_ISR()                              ulPortGetIPL(); portDISABLE_INTERRUPTS()
-    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( uxSavedInterruptStatus )
+uint32_t ulPortGetIPL( void ) __attribute__((naked));
+void vPortSetIPL( uint32_t ulNewIPL ) __attribute__((naked));
+
+ static int32_t set_interrupt_mask_from_isr( void );
+ static int32_t set_interrupt_mask_from_isr( void )
+ {
+	 int32_t tmp = ulPortGetIPL();
+	 vPortSetIPL( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+	 return tmp;
+ }
+ #define portSET_INTERRUPT_MASK_FROM_ISR()    set_interrupt_mask_from_isr()
+ #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/Renesas/RX100/portmacro.h
+++ b/portable/Renesas/RX100/portmacro.h
@@ -124,8 +124,17 @@ extern void vTaskExitCritical( void );
 #define portEXIT_CRITICAL()		vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-#define portSET_INTERRUPT_MASK_FROM_ISR() ( UBaseType_t ) get_ipl(); set_ipl( ( signed long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) set_ipl( ( signed long ) uxSavedInterruptStatus )
+static int32_t set_interrupt_mask_from_isr( void );
+static int32_t set_interrupt_mask_from_isr( void )
+{
+int32_t tmp = __get_ipl();
+__set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+return tmp;
+}
+#define portSET_INTERRUPT_MASK_FROM_ISR()
+set_interrupt_mask_from_isr()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )
+set_ipl( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/Renesas/RX200/portmacro.h
+++ b/portable/Renesas/RX200/portmacro.h
@@ -124,8 +124,17 @@ extern void vTaskExitCritical( void );
 #define portEXIT_CRITICAL()		vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-#define portSET_INTERRUPT_MASK_FROM_ISR() get_ipl(); set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) set_ipl( ( long ) uxSavedInterruptStatus )
+static int32_t set_interrupt_mask_from_isr( void );
+static int32_t set_interrupt_mask_from_isr( void )
+{
+int32_t tmp = __get_ipl();
+__set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+return tmp;
+}
+#define portSET_INTERRUPT_MASK_FROM_ISR()
+set_interrupt_mask_from_isr()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )
+set_ipl( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/Renesas/RX600/portmacro.h
+++ b/portable/Renesas/RX600/portmacro.h
@@ -125,8 +125,17 @@ extern void vTaskExitCritical( void );
 #define portEXIT_CRITICAL()		vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-#define portSET_INTERRUPT_MASK_FROM_ISR() get_ipl(); set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) set_ipl( ( long ) uxSavedInterruptStatus )
+static int32_t set_interrupt_mask_from_isr( void );
+static int32_t set_interrupt_mask_from_isr( void )
+{
+int32_t tmp = __get_ipl();
+__set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+return tmp;
+}
+#define portSET_INTERRUPT_MASK_FROM_ISR()
+set_interrupt_mask_from_isr()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )
+set_ipl( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/Renesas/RX600v2/portmacro.h
+++ b/portable/Renesas/RX600v2/portmacro.h
@@ -125,8 +125,17 @@ extern void vTaskExitCritical( void );
 #define portEXIT_CRITICAL()		vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-#define portSET_INTERRUPT_MASK_FROM_ISR() ( UBaseType_t ) get_ipl(); set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) set_ipl( ( long ) uxSavedInterruptStatus )
+static int32_t set_interrupt_mask_from_isr( void );
+static int32_t set_interrupt_mask_from_isr( void )
+{
+int32_t tmp = __get_ipl();
+__set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+return tmp;
+}
+#define portSET_INTERRUPT_MASK_FROM_ISR()
+set_interrupt_mask_from_isr()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )
+set_ipl( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/Renesas/RX700v3_DPFPU/portmacro.h
+++ b/portable/Renesas/RX700v3_DPFPU/portmacro.h
@@ -150,8 +150,17 @@
     #define portEXIT_CRITICAL()     vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-    #define portSET_INTERRUPT_MASK_FROM_ISR()                              ( UBaseType_t ) get_ipl(); set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    set_ipl( ( long ) uxSavedInterruptStatus )
+static int32_t set_interrupt_mask_from_isr( void );
+static int32_t set_interrupt_mask_from_isr( void )
+{
+int32_t tmp = __get_ipl();
+__set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY );
+return tmp;
+}
+#define portSET_INTERRUPT_MASK_FROM_ISR()
+set_interrupt_mask_from_isr()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )
+set_ipl( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->
Description
-----------
Updated portSET_INTERRUPT_MASK_FROM_ISR to a macro refer to real function in portmacro.h for both CCRX and GCC (included: RX100, RX200, RX600, RX600v2, RX700v3_DPFPU)
<!--- Describe your changes in detail. -->

Test Steps
-----------
Build Test
Test with Tracealyzer Debugging
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
Jira: https://ree-du1tcsi2.ree.adwin.renesas.com/browse/ISDRXFITRDVRO-739 
<!-- If any, please provide issue ID. -->